### PR TITLE
Changes for PHP7 compatibility

### DIFF
--- a/action/display.php
+++ b/action/display.php
@@ -34,7 +34,7 @@ class action_plugin_linkback_display extends DokuWiki_Action_Plugin {
     /**
      * Constructor
      */
-    function action_plugin_linkback_display() {
+    function __construct() {
         $this->tools =& plugin_load('tools', 'linkback');
     }
 

--- a/exe/pingback.php
+++ b/exe/pingback.php
@@ -42,7 +42,7 @@ class PingbackServer extends IXR_Server {
      */
     function PingbackServer() {
         $this->tools =& plugin_load('tools', 'linkback');
-        $this->IXR_Server(array (
+        parent::__construct(array (
             'pingback.ping' => 'this:ping',
             
         ));

--- a/exe/pingback.php
+++ b/exe/pingback.php
@@ -40,7 +40,7 @@ class PingbackServer extends IXR_Server {
     /**
      * Register service and construct helper
      */
-    function PingbackServer() {
+    function __construct() {
         $this->tools =& plugin_load('tools', 'linkback');
         parent::__construct(array (
             'pingback.ping' => 'this:ping',

--- a/exe/trackback.php
+++ b/exe/trackback.php
@@ -29,7 +29,7 @@ class TrackbackServer {
     /**
      * Construct helper and process request.
      */
-    function TrackbackServer() {
+    function __construct() {
         $this->tools =& plugin_load('tools', 'linkback');
         $this->_process();
     }

--- a/http.php
+++ b/http.php
@@ -18,7 +18,7 @@ class LinkbackHTTPClient extends DokuHTTPClient {
 
     var $max_bodysize_limit = false;
 
-    function LinkbackHTTPClient() {
+    function __construct() {
         parent::__construct();
     }
 


### PR DESCRIPTION
Sorry, I'm not good at English...

Fixed issue that `Undefined method call` occurs at call super class constructor `$this->IXR_Server()` when pingback.php receives pingback. I think to this error occurs Because constructor method name of super class `IXR_Server` has changed from `IXR_Server()` to `__construct()`.

And one more, I changed some constructor method names that cause of warning: `Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP`. Since DokuWiki PHP requirements is 5.6 or later, I think that there is no problem with this change.

My environment is following.
- PHP 7.0.15
- dokuwiki 2017-02-19b

Best regards.
